### PR TITLE
Fix links in Install/Uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ Unity Cache Server Installer for OS X
 
 ## Install 
 
-curl -s https://raw.github.com/tnayuki/unitycache-osx-installer/master/install.sh | sudo bash -s http://netstorage.unity3d.com/unity/CacheServer-4.3.4.zip
+curl -s https://raw.githubusercontent.com/tnayuki/unitycache-osx-installer/master/install.sh | sudo bash -s http://netstorage.unity3d.com/unity/CacheServer-4.3.4.zip
 
 will install Unity Cache Server version 4.3.4.
 
 ## Uninstall
 
-curl -s https://raw.github.com/tnayuki/unitycache-osx-installer/master/uninstall.sh | sudo bash
+curl -s https://raw.githubusercontent.com/tnayuki/unitycache-osx-installer/master/uninstall.sh | sudo bash


### PR DESCRIPTION
raw.github.com doesn't work now, but raw.githubusercontent.com does.